### PR TITLE
Move password to body instead of query parameter for file upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,7 +1101,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waifuvault"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waifuvault"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Graham Keenan graham.keenan@outlook.com"]
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,10 +198,12 @@ impl ApiCaller {
                     form = form.text("password", password);
                 }
 
+                println!("Form data: {form:?}");
+
                 intermediate = intermediate.multipart(form);
             } else if let Some(url) = request.url {
                 intermediate = match request.password {
-                    Some(password) => intermediate.form(&[("url", url, "password", password)]),
+                    Some(password) => intermediate.form(&[("url", url), ("password", password)]),
                     None => intermediate.form(&[("url", url)]),
                 };
             } else if let (Some(raw), Some(filename)) = (request.bytes, request.filename) {
@@ -212,6 +214,7 @@ impl ApiCaller {
                     form = form.text("password", password);
                 }
 
+                println!("Form data: {form:?}");
                 intermediate = intermediate.multipart(form);
             } else {
                 anyhow::bail!("need either a file, url, or stream");
@@ -220,6 +223,7 @@ impl ApiCaller {
             intermediate
         };
 
+        // println!("Request: {request:?}");
         let response = request
             .send()
             .await
@@ -486,7 +490,11 @@ mod tests {
         let caller = ApiCaller::new();
         let upload_request = api::WaifuUploadRequest::new().file(&tmp.file);
 
-        let response = caller.upload_file(upload_request).await;
+        let response = caller
+            .upload_file(upload_request)
+            .await
+            .context("upload file - basic");
+
         assert!(response.is_ok());
 
         let response = response?;
@@ -515,7 +523,10 @@ mod tests {
             .one_time_download(true)
             .hide_filename(true);
 
-        let response = caller.upload_file(upload_request).await?;
+        let response = caller
+            .upload_file(upload_request)
+            .await
+            .context("upload file with options")?;
         let options = response
             .options
             .expect("expected options when there are none");
@@ -536,7 +547,10 @@ mod tests {
         let caller = ApiCaller::new();
         let request = WaifuUploadRequest::new().url(url).expires("1h");
 
-        let response = caller.upload_file(request).await?;
+        let response = caller
+            .upload_file(request)
+            .await
+            .context("upload from url")?;
         let options = response
             .options
             .expect("expected options when there are none");
@@ -698,7 +712,10 @@ mod tests {
             .url(url)
             .expires("1h")
             .password("banana");
-        let response = caller.upload_file(request).await?;
+        let response = caller
+            .upload_file(request)
+            .await
+            .context("uploading protected file to download")?;
         let url = response.url;
 
         let response = caller


### PR DESCRIPTION
This PR moves the `password` field into the form body instead of the query parameters for the `upload_file` API call to support the new workflow in the parent API.